### PR TITLE
Afficher correctement la gestion de HTTPS

### DIFF
--- a/front/src/cells/https/Valid.js
+++ b/front/src/cells/https/Valid.js
@@ -16,7 +16,7 @@ class HttpsValid extends Component {
       )
     } else {
       return (
-        <Badge status='warning' text='HTTPS non valide' icon='fa-exclamation-triangle'/>
+        <Badge status='invalid' text='HTTPS non valide' icon='fa-exclamation-triangle'/>
       )
     }
   }

--- a/front/test/HttpValid-test.js
+++ b/front/test/HttpValid-test.js
@@ -26,7 +26,7 @@ describe("HttpsValid", () => {
     const inspect = {}
     inspect["Valid HTTPS"] = false
     it("contains a invalid badge", () => {
-      const expectedValue = <Badge status='warning' text='HTTPS non valide' icon='fa-exclamation-triangle'/>
+      const expectedValue = <Badge status='invalid' text='HTTPS non valide' icon='fa-exclamation-triangle'/>
       expect(shallow(<HttpsValid inspect={inspect} />).contains(expectedValue)).to.equal(true)
     })
   })


### PR DESCRIPTION
Si HTTPS n'est pas valide, ce n'est pas un avertissement qu'il faut afficher