### PR TITLE
Fix recursive test

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "lint": "eslint ./src/",
-    "test": "mocha test/.setup.js src/**/*-test.js",
+    "test": "mocha test/.setup.js $(find ./src -d -name '*-test.js')",
     "dev": "mocha test/.setup.js src/**/*-test.js --watch"
   },
   "eslintConfig": {

--- a/front/src/Charts/Bool/Bool-test.js
+++ b/front/src/Charts/Bool/Bool-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { shallow, mount } from 'enzyme'
 import Bool from './Bool'
 
-const arraySite = require('./resources/array-sites')
+const arraySite = require('../../../test/resources/array-sites')
 
 describe("Bool", () => {
 
@@ -23,17 +23,17 @@ describe("Bool", () => {
       }, 10)
     })
 
-    it('should display label', (done) => {
-      const wrapper = mount(<Bool sites={arraySite} property="Valid HTTPS" label="label" />)
+    it('should display title', (done) => {
+      const wrapper = mount(<Bool sites={arraySite} property="Valid HTTPS" title="title" />)
 
       setTimeout(() => {
-        expect(wrapper.text()).to.contain(wrapper.props().label)
+        expect(wrapper.text()).to.contain(wrapper.props().title)
         done()
       }, 10)
     })
 
     it('should display percent', (done) => {
-      const wrapper = mount(<Bool sites={arraySite} property="Valid HTTPS" label="label" />)
+      const wrapper = mount(<Bool sites={arraySite} property="Valid HTTPS" label="label"/>)
 
       setTimeout(() => {
         expect(wrapper.text()).to.contain('100%')
@@ -64,7 +64,7 @@ describe("Bool", () => {
     })
 
     it('should 50% https', (done) => {
-      let newArraySite = arraySite
+      let newArraySite = arraySite.slice()
       newArraySite[0].inspect["Valid HTTPS"] = false
       const wrapper = mount(<Bool sites={newArraySite} property="Valid HTTPS" label="label" />)
 
@@ -75,7 +75,7 @@ describe("Bool", () => {
     })
 
     it('should 0% https', (done) => {
-      let newArraySite = arraySite
+      let newArraySite = arraySite.slice()
       newArraySite.forEach(function(element) {
         element.inspect["Valid HTTPS"] = false
       })

--- a/front/src/Charts/Categories/Categories-test.js
+++ b/front/src/Charts/Categories/Categories-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { shallow, mount } from 'enzyme'
 import Categories from './Categories'
 
-const arraySite = require('./resources/array-sites')
+const arraySite = require('../../../test/resources/array-sites')
 
 describe("Categories", () => {
   const wrapper = shallow(<Categories sites={arraySite} />)

--- a/front/src/cells/https/Enforce/EnforceHttps-test.js
+++ b/front/src/cells/https/Enforce/EnforceHttps-test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { expect } from 'chai'
 import { shallow } from 'enzyme'
-import Badge from '../../cells/Badge'
+import Badge from '../../Badge/Badge'
 import HttpsEnforce from './Enforce'
 
 

--- a/front/src/cells/uptime/CustomUptimeRatio/CustomUptimeRatio-test.js
+++ b/front/src/cells/uptime/CustomUptimeRatio/CustomUptimeRatio-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { expect } from 'chai'
 import { shallow } from 'enzyme'
 import CustomUptimeRatio from './CustomUptimeRatio'
-import UptimeRatio from './UptimeRatio/UptimeRatio'
+import UptimeRatio from '../UptimeRatio/UptimeRatio'
 
 describe('CustomUptimeRatio', () => {
   describe('when there is no data', () => {


### PR DESCRIPTION
La récursive de la commande `mocha` ne va pas chercher toutes les tests.