### PR TITLE
Ajout de site data.gouv.fr manquants

### DIFF
--- a/data/sites.csv
+++ b/data/sites.csv
@@ -30,3 +30,7 @@ franceconnect.gouv.fr,DINSIC,website,m778110641-2f18b099476c0446caadb2d4
 app.franceconnect.gouv.fr,DINSIC,api,m778110642-297e042b7b2d10465d092c96
 www.etalab.gouv.fr,Etalab,website,m778220995-6ccde5b777ac7150ebdab27a
 agd.data.gouv.fr,Etalab,website,m778220997-a8b7ae78d0677015e7752629
+check.data.gouv.fr,Etalab,website,m778456843-b3cb5fc2b3a4fb05a028cf42
+sentry.data.gouv.fr,Etalab,website,m778456884-818f466a6c9b189994b6b480
+id.data.gouv.fr,Etalab,website,m778476545-2993f6c21bc5fc5a0e42d09e
+stats.data.gouv.fr,Etalab,website,m778476526-3848e6bfa9ed9fc6d3cb7b4b


### PR DESCRIPTION
Ajouts des sites suivants:

- id.data.gouv.fr
- check.data.gouv.fr
- sentry.data.gouv.fr
- stats.data.gouv.fr